### PR TITLE
Properly re-connect to server during a test run

### DIFF
--- a/meteor/src/lib/MochaRunner.coffee
+++ b/meteor/src/lib/MochaRunner.coffee
@@ -44,6 +44,10 @@ class MochaRunner
           check(runId, String);
           expect(@ready).to.be.a('function')
           self.publishers[runId] ?= @
+
+          @onStop =>
+            delete self.publishers[runId]
+
           @ready()
           # You can't return any other value but a Cursor, otherwise it will throw an exception
           return undefined
@@ -70,7 +74,12 @@ class MochaRunner
 
       mochaRunner.reporter(MeteorPublishReporter, {
         grep: @escapeGrep(grep)
-        publisher: @publishers[runId]
+        publisher:
+          added: => @publishers[runId]?.added.apply(@publishers[runId], arguments)
+          changed: => @publishers[runId]?.changed.apply(@publishers[runId], arguments)
+          removed: => @publishers[runId]?.removed.apply(@publishers[runId], arguments)
+          ready: => @publishers[runId]?.ready.apply(@publishers[runId], arguments)
+          onStop: => @publishers[runId]?.onStop.apply(@publishers[runId], arguments)
       })
 
       log.info "Starting server side tests with run id #{runId}"

--- a/meteor/src/reporters/MeteorPublishReporter.coffee
+++ b/meteor/src/reporters/MeteorPublishReporter.coffee
@@ -25,10 +25,6 @@ class MeteorPublishReporter extends BaseReporter
       expect(@publisher.added, '@publisher.added').to.be.a('function')
       expect(@publisher.onStop, '@publisher.onStop').to.be.a('function')
 
-
-      @publisher.onStop =>
-        @stopped = true
-      @stopped = false
       @sequence = 0
 
       # Specify how to run tests 'serial' or 'parallel'
@@ -103,7 +99,6 @@ class MeteorPublishReporter extends BaseReporter
     try
       log.enter 'added', arguments
 #      log.info event, data
-      return if @stopped is true
       @sequence++
       doc =
         _id: "#{@sequence}"


### PR DESCRIPTION
Currently, if the client disconnects during a test run (which I was seeing intermittently while running my tests in selenium), the publication with server-side test results doesn't work correctly when the client reconnects.

This PR makes the client and server correctly handle a disconnect/reconnect.
