### PR TITLE
CoffeeScript 2 compatibility

### DIFF
--- a/.versions
+++ b/.versions
@@ -27,7 +27,7 @@ htmljs@1.0.10
 http@1.1.7
 id-map@1.0.8
 jquery@1.11.9
-local-test:practicalmeteor:mocha@2.4.5_6
+local-test:practicalmeteor:mocha@2.4.5_7
 logging@1.0.13_1
 meteor@1.1.15_1
 minifier-js@1.1.12_1
@@ -41,7 +41,7 @@ observe-sequence@1.0.12
 ordered-dict@1.0.8
 practicalmeteor:chai@2.1.0_1
 practicalmeteor:loglevel@1.2.0_2
-practicalmeteor:mocha@2.4.5_6
+practicalmeteor:mocha@2.4.5_7
 practicalmeteor:mocha-core@1.0.1
 practicalmeteor:sinon@1.14.1_2
 promise@0.7.2_1

--- a/meteor/CHANGELOG.md
+++ b/meteor/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.4.5_7
+
+- Updates for CoffeeScript 2 compatibility.
+
 # 2.4.5_6
 
 - Add `ConsoleReporter` and `XunitReporter` more details in how to run then [HERE]().
@@ -9,15 +13,15 @@
 
 # 2.4.5_4
 
-- Fix bug related to firing 'end all' mocha runner event. [More details](https://github.com/practicalmeteor/meteor-mocha-console-runner/issues/6)  
+- Fix bug related to firing 'end all' mocha runner event. [More details](https://github.com/practicalmeteor/meteor-mocha-console-runner/issues/6)
 
 # 2.4.5_3
 
-- Bug fixes (more details below) - [#42](https://github.com/practicalmeteor/meteor-mocha/issues/42), [#44](https://github.com/practicalmeteor/meteor-mocha/issues/44), [#45](https://github.com/practicalmeteor/meteor-mocha/issues/45), 
+- Bug fixes (more details below) - [#42](https://github.com/practicalmeteor/meteor-mocha/issues/42), [#44](https://github.com/practicalmeteor/meteor-mocha/issues/44), [#45](https://github.com/practicalmeteor/meteor-mocha/issues/45),
 
 - Add an acceptance test that includes most mocha test scenarios by verifying that the actual html produced by the reporter matches the expected one. The acceptance test runs both `meteor test`, `meteor test --full-app` and `meteor test-packages` and runs in ci.
 
-- Move dependency on mocha to mocha-core, and depend on mocha's npm 
+- Move dependency on mocha to mocha-core, and depend on mocha's npm
 package, instead of the forked source code - fixes [#23](https://github.com/practicalmeteor/meteor-mocha/issues/23) - conflict with dispatch:mocha-phantomjs
 
 - Properly support promises returned from mocha functions - fixes [#44](https://github.com/practicalmeteor/meteor-mocha/issues/44)

--- a/meteor/src/lib/MochaRunner.coffee
+++ b/meteor/src/lib/MochaRunner.coffee
@@ -24,6 +24,7 @@ class MochaRunner extends EventEmitter
   constructor: ->
     try
       log.enter 'constructor'
+      super()
       @utils = utils;
       @serverRunEvents = new Mongo.Collection('mochaServerRunEvents')
       if Meteor.isServer

--- a/meteor/src/lib/MochaRunner.coffee
+++ b/meteor/src/lib/MochaRunner.coffee
@@ -16,7 +16,7 @@ class MochaRunner extends EventEmitter
   @get: ->
     MochaRunner.instance ?= new MochaRunner()
 
-  VERSION: "2.4.5_6"
+  VERSION: "2.4.5_7"
   serverRunEvents: null
   publishers: {}
 

--- a/meteor/src/reporters/ConsoleReporter.coffee
+++ b/meteor/src/reporters/ConsoleReporter.coffee
@@ -8,10 +8,13 @@ log = new ObjectLogger('ConsoleReporter', 'info')
 class ConsoleReporter extends  ClientServerBaseReporter
 
 
-  constructor: (@clientRunner, @serverRunner, @options)->
+  constructor: (clientRunner, serverRunner, options)->
     try
       log.enter('constructor')
-      super(@clientRunner, @serverRunner, @options)
+      super(clientRunner, serverRunner, options)
+      @clientRunner = clientRunner
+      @serverRunner = serverRunner
+      @options = options
       MochaRunner.on "end all", => @finishAndPrintTestsSummary()
 
     finally

--- a/meteor/src/reporters/HtmlReporter.coffee
+++ b/meteor/src/reporters/HtmlReporter.coffee
@@ -7,16 +7,19 @@ log = new ObjectLogger('HtmlReporter', 'info')
 
 class HtmlReporter extends ClientServerBaseReporter
 
-  constructor: (@clientRunner, @serverRunner, @options = {})->
+  constructor: (clientRunner, serverRunner, options = {})->
     try
       log.enter('constructor')
+      super(clientRunner, serverRunner, options)
+      @clientRunner = clientRunner
+      @serverRunner = serverRunner
+      @options = options
       @addReporterHtml()
 
       @reporter = new MochaHtmlReporter(@clientRunner)
       @serverReporter = new MochaHtmlReporter(@serverRunner, {
         elementIdPrefix: 'server-'
       })
-      super(@clientRunner, @serverRunner, @options)
     finally
       log.return()
 

--- a/meteor/src/reporters/XunitReporter.coffee
+++ b/meteor/src/reporters/XunitReporter.coffee
@@ -6,7 +6,11 @@ class XUnitReporter extends ConsoleReporter
   @VERSION: "0.1.0"
   xUnitPrefix: "##_meteor_magic##xunit: "
 
-  constructor:(@clientRunner, @serverRunner, @options)->
+  constructor:(clientRunner, serverRunner, options)->
+    super(clientRunner, serverRunner, options)
+    @clientRunner = clientRunner
+    @serverRunner = serverRunner
+    @options = options
 
     @clientTests = []
     @serverTests = []
@@ -14,8 +18,6 @@ class XUnitReporter extends ConsoleReporter
     # ConsoleReporter exposes global variables that indicates when the tests has finished,
     # so we register the event to print the test suite before ConsoleReporter register its event
     MochaRunner.on "end all", => @printTestSuite()
-
-    super(@clientRunner, @serverRunner, @options)
 
 
   ###

--- a/meteor/test-app/.meteor/packages
+++ b/meteor/test-app/.meteor/packages
@@ -19,6 +19,6 @@ ecmascript              # Enable ECMAScript2015+ syntax in app code
 
 autopublish             # Publish all data to the clients (for prototyping)
 insecure                # Allow all DB writes from clients (for prototyping)
-practicalmeteor:mocha@=2.4.5_6
+practicalmeteor:mocha@=2.4.5_7
 practicalmeteor:chai
 practicalmeteor:loglevel

--- a/meteor/test-app/.meteor/versions
+++ b/meteor/test-app/.meteor/versions
@@ -52,7 +52,7 @@ observe-sequence@1.0.12
 ordered-dict@1.0.8
 practicalmeteor:chai@2.1.0_1
 practicalmeteor:loglevel@1.2.0_2
-practicalmeteor:mocha@2.4.5_6
+practicalmeteor:mocha@2.4.5_7
 practicalmeteor:mocha-core@1.0.1
 practicalmeteor:sinon@1.14.1_2
 promise@0.7.2

--- a/meteor/test-package/package.js
+++ b/meteor/test-package/package.js
@@ -24,7 +24,7 @@ Package.onTest(function (api) {
     'coffeescript',
     'practicalmeteor:loglevel',
     'practicalmeteor:chai',
-    'practicalmeteor:mocha@=2.4.5_6',
+    'practicalmeteor:mocha@=2.4.5_7',
     'ecmascript',
     'test-package'
   ]);

--- a/package.js
+++ b/package.js
@@ -25,8 +25,6 @@ Npm.depends({
 });
 
 Package.onUse(function (api) {
-  api.versionsFrom("1.3");
-
   api.use('tmeasday:test-reporter-helpers@0.2.1');
   api.use('coffeescript');
   api.use('reload');

--- a/package.js
+++ b/package.js
@@ -3,7 +3,7 @@ Package.describe({
   name: "practicalmeteor:mocha",
   summary: "Write package tests with mocha and run them in the browser or from the command line with spacejam.",
   git: "https://github.com/practicalmeteor/meteor-mocha.git",
-  version: '2.4.5_6',
+  version: '2.4.5_7',
   testOnly: true
 });
 


### PR DESCRIPTION
See https://github.com/meteor/meteor/pull/9107#issuecomment-337091582.

I’m working on bringing CoffeeScript 2 into Meteor’s `coffeescript` package. To do so, and not break Meteor’s own CI tests, `meteor-mocha` needs to be updated so that it’s compatible with CoffeeScript 2. Fortunately the only change that I think it needs is to [not refer to `this` before `super` in class constructors](http://coffeescript.org/#breaking-changes-classes), a rather silly requirement of ES2015 classes that CoffeeScript 2 is forced to abide by since CS2 outputs classes using the ES `class` keyword. I’ve updated the classes in question, and I don’t think my changes have any meaningful impact. These changes should make `meteor-mocha`‘s code compatible with either CoffeeScript 1 or 2.